### PR TITLE
Add other brands, fix switches, restructure code

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,14 +28,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     reg = device_registry.async_get(hass)
-    reg.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, coordinator.unique_id)},
-        manufacturer="Purmo",
-        model="Touch E3",
-        name="Touch E3",
-        configuration_url="https://e3.lvi.eu/",
-    )
+
+    for home_id, home in coordinator.homes.items():
+        reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, coordinator.get_unique_home_id(home_id))},
+            manufacturer=coordinator.model.manufacturer,
+            model=coordinator.model.controller,
+            name=f"{home.info.label} {coordinator.model.controller}",
+            suggested_area=home.info.label,
+            configuration_url=coordinator.host,
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/climate.py
+++ b/climate.py
@@ -1,3 +1,4 @@
+"""CleverTouch climate entities"""
 from typing import Optional
 
 from homeassistant.components.climate import (
@@ -25,7 +26,6 @@ from .const import (
     TEMP_NATIVE_PRECISION,
 )
 from clevertouch.devices import Radiator, HeatMode, TempType
-from clevertouch.devices.radiator import Temperature
 from .coordinator import CleverTouchUpdateCoordinator, CleverTouchEntity
 
 
@@ -66,10 +66,9 @@ class RadiatorEntity(CleverTouchEntity, ClimateEntity):
 
         self.entity_description = ClimateEntityDescription(
             icon="mdi:radiator",
-            name="",
+            has_entity_name=False,
             key="radiator",
         )
-        self._attr_unique_id = f"{radiator.device_id}-{self.entity_description.key}"
 
         self._attr_target_temperature_step = TEMP_NATIVE_STEP
         self._attr_precision = TEMP_NATIVE_PRECISION

--- a/const.py
+++ b/const.py
@@ -1,6 +1,7 @@
 """Constants for the Clever Touch E3 integration."""
 from clevertouch.devices import TempUnit
 from homeassistant.const import UnitOfTemperature
+from collections import namedtuple
 
 DOMAIN = "clevertouch"
 
@@ -14,3 +15,37 @@ TEMP_NATIVE_PRECISION = 0.1
 DEFAULT_SCAN_INTERVAL_SECONDS = 180
 QUICK_SCAN_INTERVAL_SECONDS = 15
 QUICK_SCAN_COUNT = 3
+
+Model = namedtuple("Model", ["manufacturer", "app", "url", "controller"])
+
+DEFAULT_MODEL_ID = "purmo"
+MODELS = {
+    "purmo": Model("Purmo", "CleverTouch", "e3.lvi.eu", "Touch E3"),
+    "waltermeier": Model(
+        "Walter Meier",
+        "Walter Meier Smart-Comfort",
+        "www.smartcomfort.waltermeier.com",
+        "Metalplast Smart-Comfort",
+    ),
+    "frico": Model(
+        "Frico",
+        "Frico FP Smart",
+        "fricopfsmart.frico.se",
+        "Central Unit",
+    ),
+    "fenix": Model(
+        "Fenix", "Fenix V24 Wifi", "v24.fenixgroup.eu", "Smart Home Controller"
+    ),
+    "vogelundnoot": Model(
+        "Vogel & Noot",
+        "Vogel & Noot E3",
+        "e3.vogelundnoot.com",
+        "Touch E3",
+    ),
+    "cordivari": Model(
+        "Cordivari",
+        "Cordivari My Way",
+        "cordivarihome.com",
+        "My Way",
+    ),
+}

--- a/coordinator.py
+++ b/coordinator.py
@@ -7,7 +7,13 @@ import logging
 
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_TOKEN
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_TOKEN,
+    CONF_USERNAME,
+    CONF_HOST,
+    CONF_MODEL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -22,8 +28,10 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_SECONDS,
     QUICK_SCAN_INTERVAL_SECONDS,
     QUICK_SCAN_COUNT,
+    MODELS,
+    DEFAULT_MODEL_ID,
 )
-from clevertouch import Account, Home
+from clevertouch import Account, Home, User
 from clevertouch.devices import Device
 
 SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL_SECONDS)
@@ -35,14 +43,19 @@ class CleverTouchUpdateCoordinator(DataUpdateCoordinator[None]):
 
     def __init__(self, hass: HomeAssistant, *, entry: ConfigEntry) -> None:
         """Initialize data updater."""
-        self._email = entry.data[CONF_EMAIL]
-        self._unique_id = self._email.lower()
-        self.api_session: Account = Account(self._email, entry.data[CONF_TOKEN])
+        self._email = entry.data.get(CONF_USERNAME) or entry.data[CONF_EMAIL]
+        self.model_id = entry.data.get(CONF_MODEL) or DEFAULT_MODEL_ID
+        self.model = MODELS[self.model_id]
+        self.host = entry.data.get(CONF_HOST) or f"https://{self.model.url}"
+        self.api_session: Account = Account(
+            self._email, entry.data[CONF_TOKEN], host=self.host
+        )
+        self.user: Optional[User] = None
         self.homes: dict[str, Home] = {}
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}-{self._email.lower()}",
+            name=f"{DOMAIN}-{self.model_id}-{self._email.lower()}",
             update_interval=SCAN_INTERVAL,
         )
         self._quick_updates = QuickUpdatesController(
@@ -63,10 +76,10 @@ class CleverTouchUpdateCoordinator(DataUpdateCoordinator[None]):
             return
 
         if not self.homes:
-            user = await self.api_session.get_user()
+            self.user = await self.api_session.get_user()
             self.homes = {
                 home_id: await self.api_session.get_home(home_id)
-                for home_id in user.homes
+                for home_id in self.user.homes
             }
             _LOGGER.debug("Retrieved %d new homes from CleverTouch", len(self.homes))
         else:
@@ -74,15 +87,9 @@ class CleverTouchUpdateCoordinator(DataUpdateCoordinator[None]):
                 await home.refresh()
             _LOGGER.debug("Refreshed homes from CleverTouch")
 
-    @property
-    def unique_id(self) -> str:
-        """Return unique id for this coordinator."""
-        return self._unique_id
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for the main device."""
-        return DeviceInfo(identifiers={(DOMAIN, self.unique_id)})
+    def get_unique_home_id(self, home_id) -> str:
+        """Return the unique id for a home."""
+        return f"{self.model_id}_{home_id}"
 
 
 class CleverTouchEntity(CoordinatorEntity[CleverTouchUpdateCoordinator]):
@@ -96,12 +103,17 @@ class CleverTouchEntity(CoordinatorEntity[CleverTouchUpdateCoordinator]):
         self.device: Device = device
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, device.device_id)},
-            manufacturer="Purmo",
-            model=f"Purmo {device.device_type}",
+            identifiers={(DOMAIN, f"{coordinator.model_id}_{device.device_id}")},
+            manufacturer=coordinator.model.manufacturer,
+            model=f"{device.device_type}",
             name=f"{device.zone.label} {device.label}",
-            via_device=(DOMAIN, coordinator.unique_id),
+            via_device=(DOMAIN, coordinator.get_unique_home_id(device.home.home_id)),
+            suggested_area=device.zone.label,
         )
+
+    @property
+    def unique_id(self) -> str | None:
+        return f"{self.coordinator.model_id}_{self.device.device_id}_{self.entity_description.key}"
 
 
 class QuickUpdatesController:

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "clevertouch",
-  "name": "Clever Touch E3",
+  "name": "CleverTouch",
   "config_flow": true,
   "documentation": "https://github.com/hemphen/hass-clevertouch",
-  "requirements": ["clevertouch==0.2.4"],
+  "requirements": ["clevertouch==0.3.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@hemphen"],
   "iot_class": "cloud_polling",
-  "version": "0.2.7"
+  "version": "0.3.0"
 }

--- a/number.py
+++ b/number.py
@@ -72,7 +72,6 @@ class TemperatureNumberEntity(CleverTouchEntity, NumberEntity):
             native_max_value=TEMP_NATIVE_MAX,
             native_min_value=TEMP_NATIVE_MIN,
         )
-        self._attr_unique_id = f"{radiator.device_id}-{self.entity_description.key}"
 
     @property
     def native_value(self) -> Optional[float]:

--- a/sensor.py
+++ b/sensor.py
@@ -65,7 +65,6 @@ class TemperatureSensorEntity(CleverTouchEntity, SensorEntity):
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=TEMP_HA_UNIT,
         )
-        self._attr_unique_id = f"{radiator.device_id}-{self.entity_description.key}"
 
     @property
     def native_value(self) -> Optional[float]:

--- a/switch.py
+++ b/switch.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from clevertouch.devices import Outlet
+from clevertouch.devices import OnOffDevice, DeviceType
 
 from .const import (
     DOMAIN,
@@ -30,50 +30,49 @@ async def async_setup_entry(
     coordinator: CleverTouchUpdateCoordinator = hass.data[DOMAIN].get(entry.entry_id)
 
     entities = [
-        OutletEntity(coordinator, device)
+        CleverTouchSwitchEntity(coordinator, device)
         for home in coordinator.homes.values()
         for device in home.devices.values()
-        if isinstance(device, Outlet)
+        if isinstance(device, OnOffDevice)
     ]
 
     async_add_entities(entities)
 
 
-class OutletEntity(CleverTouchEntity, SwitchEntity):
+class CleverTouchSwitchEntity(CleverTouchEntity, SwitchEntity):
     """Representation of a CleverTouch configurable temperature."""
 
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: CleverTouchUpdateCoordinator, outlet: Outlet
+        self, coordinator: CleverTouchUpdateCoordinator, switch: OnOffDevice
     ) -> None:
-        super().__init__(coordinator, outlet)
+        super().__init__(coordinator, switch)
 
-        self._outlet = outlet
-        self.entity_description = SwitchEntityDescription(
-            icon="mdi:power-plug",
-            device_class=SwitchDeviceClass.OUTLET,
-            name="",
-            key="outlet",
+        self._switch = switch
+        device_class = (
+            SwitchDeviceClass.OUTLET
+            if switch.device_type == DeviceType.OUTLET
+            else SwitchDeviceClass.SWITCH
         )
-        self._attr_unique_id = f"{outlet.device_id}-{self.entity_description.key}"
+        self.entity_description = SwitchEntityDescription(
+            device_class=device_class,
+            has_entity_name=False,
+            key=device_class,
+        )
 
     @property
     def is_on(self) -> Optional[bool]:
-        return self._outlet.is_on
-
-    @property
-    def icon(self) -> Optional[str]:
-        return "mdi:power-plug" if self.is_on else "mdi:power-plug-off"
+        return self._switch.is_on
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         if self.is_on:
             return
-        await self._outlet.set_onoff_state(True)
+        await self._switch.set_onoff_state(True)
         await self.coordinator.async_request_delayed_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         if not self.is_on:
             return
-        await self._outlet.set_onoff_state(False)
+        await self._switch.set_onoff_state(False)
         await self.coordinator.async_request_delayed_refresh()


### PR DESCRIPTION
* Other brands than (Purmo) CleverTouch are now supported. They have not been tested with any real homes/devices so use with caution and expect minor glitches, like missing or extra features avialable compared to the actual device.

* Fix switches - there doesn't seem to exist a completely reliable way to tell whether a device supporting on/off is a light or an electrical outlet (or something else). More devices types are therefore now simply represented as switches.

* While implementing support for the above, code was restructured where it was deemed appropriate. This unfortunately risk introducing new bugs, so the integration is obviously still in beta (or alpha).

* Supporting new providers while maintaining old unique ids was not worth the effort. Users might need to remove and readd the integration.